### PR TITLE
Add link to openaccountants fork (three-outcome classification)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ Unfortunately i am not able to invest more time into maintaining this project.
 
 Feel free to fork it and create a PR that adds a link to your fork in the README file.
 
+### Forks
+
+- **[openaccountants/firefly-iii-ai-categorize](https://github.com/openaccountants/firefly-iii-ai-categorize)** — Three-outcome classification model (Classified / Assumed / Needs Review), modern OpenAI SDK v4, configurable model and base URL, conservative defaults principle. Actively maintained.
+
 ## How it works
 
 It provides a webhook that you can set up to be called every time a new expense is added.


### PR DESCRIPTION
As invited in the README — adding a link to our fork under the "Please fork me" section.

The fork rebuilds the classifier with a three-outcome model:
- **Classified**: confident match → category set
- **Assumed**: conservative default applied → category set with assumption disclosed in transaction notes
- **Needs Review**: can't classify → flagged for human review

Also upgrades to OpenAI SDK v4, adds configurable model/base URL, and supports any OpenAI-compatible API.

Fork: https://github.com/openaccountants/firefly-iii-ai-categorize

Made with [Cursor](https://cursor.com)